### PR TITLE
Fix backtick

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -36,7 +36,7 @@ installed Zensical:
 === "with `uv`"
 
     With an existing lock file, uv will [stick to previous versions] until you
-    explicitly upgrade them. Run the following, replacing `<version>´ with the
+    explicitly upgrade them. Run the following, replacing `<version>` with the
     version you want to upgrade to.
 
     ```


### PR DESCRIPTION
`<version>` was interpreted as HTML, disappearing from the result.