### PR TITLE
Fix social link example icon

### DIFF
--- a/docs/setup/footer.md
+++ b/docs/setup/footer.md
@@ -46,7 +46,7 @@ configuration with:
 
     ``` toml
     [[project.extra.social]]
-    icon = "fontawesome/brands/x"
+    icon = "fontawesome/brands/x-twitter"
     link = "https://x.com/zensical"
     ```
 
@@ -55,7 +55,7 @@ configuration with:
     ``` yaml
     extra:
       social:
-        - icon: fontawesome/brands/x
+        - icon: fontawesome/brands/x-twitter
           link: https://x.com/zensical
     ```
 


### PR DESCRIPTION
A small one I noticed while setting up Zensical 👍 

The social link example is showing how to add a X/Twitter link. However, the icon path was wrong: it should be `fontawesome/brands/x-twitter` instead of `fontawesome/brands/x`