### PR TITLE
fix: invalid link

### DIFF
--- a/docs/create-your-site.md
+++ b/docs/create-your-site.md
@@ -106,4 +106,4 @@ If you intend to distribute your documentation as a set of files to be
 read from a local filesystem rather than a web server (such as in a
 `.zip` file), please consult the [offline usage] guide.
 
-  [offline usage]: setup/building-for-offline-usage.md
+  [offline usage]: setup/offline.md


### PR DESCRIPTION
I'm very excited to see the brand new version of Material for Mkdocs.

When I read the new docs of Zensical, I found an invalid link, as the changed file shows.

However, the error like this will immediately appear in Material, which looks like:

```text
WARNING -  Doc file 'xxx.md' contains a link '/path/to/xxx.md', but the target '/path/to/xxx.md' is not found among documentation files.
```

I think the log info like this is very important and meaningful.