### PR TITLE
Add quotes to string value for smart_enable option

### DIFF
--- a/docs/setup/extensions/index.md
+++ b/docs/setup/extensions/index.md
@@ -101,7 +101,7 @@ extensions are active in your project:
     [project.markdown_extensions.pymdownx.arithmatex]
     generic = true
     [project.markdown_extensions.pymdownx.betterem]
-    smart_enable = all
+    smart_enable = "all"
     [project.markdown_extensions.pymdownx.caret]
     [project.markdown_extensions.pymdownx.details]
     [project.markdown_extensions.pymdownx.emoji]


### PR DESCRIPTION
When copying the provided `markdown_extensions` defaults from the docs into your `zensical.toml` file, an error like `tomllib.TOMLDecodeError: Invalid value (at line 318, column 16)` is displayed. In my case, the text at that position of the `zensical.toml` file was `smart_enable = all`. Wrapping the string value "all" in quotes resolves the issue.

## Full stack trace

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\repos\zensical\.venv\Scripts\zensical.exe\__main__.py", line 7, in <module>
  File "C:\repos\zensical\.venv\Lib\site-packages\click\core.py", line 1462, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\repos\zensical\.venv\Lib\site-packages\click\core.py", line 1383, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "C:\repos\zensical\.venv\Lib\site-packages\click\core.py", line 1850, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\repos\zensical\.venv\Lib\site-packages\click\core.py", line 1246, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\repos\zensical\.venv\Lib\site-packages\click\core.py", line 814, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\repos\zensical\.venv\Lib\site-packages\zensical\main.py", line 135, in execute_serve
    serve(os.path.abspath(config_file), dev_addr)
  File "C:\repos\zensical\.venv\Lib\site-packages\zensical\config.py", line 77, in parse_config
    return parse_zensical_config(path)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\repos\zensical\.venv\Lib\site-packages\zensical\config.py", line 88, in parse_zensical_config
    config = tomllib.load(f)
             ^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2800.0_x64__qbz5n2kfra8p0\Lib\tomllib\_parser.py", line 66, in load
    return loads(s, parse_float=parse_float)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2800.0_x64__qbz5n2kfra8p0\Lib\tomllib\_parser.py", line 102, in loads
    pos = key_value_rule(src, pos, out, header, parse_float)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2800.0_x64__qbz5n2kfra8p0\Lib\tomllib\_parser.py", line 326, in key_value_rule
    pos, key, value = parse_key_value_pair(src, pos, parse_float)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2800.0_x64__qbz5n2kfra8p0\Lib\tomllib\_parser.py", line 369, in parse_key_value_pair       
    pos, value = parse_value(src, pos, parse_float)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2800.0_x64__qbz5n2kfra8p0\Lib\tomllib\_parser.py", line 649, in parse_value
    raise suffixed_err(src, pos, "Invalid value")
tomllib.TOMLDecodeError: Invalid value (at line 318, column 16)
```