### PR TITLE
Add ReadTheDocs instructions for Zensical

### DIFF
--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -126,9 +126,6 @@ build:
     # Copy build output to ReadTheDocs expected location
     - mkdir -p _readthedocs
     - cp -r site/ _readthedocs/html/
-
-submodules:
-  include: all
 ```
 
 Once you push to your main branch, you can find all the documentation builds on RTD at `https://app.readthedocs.org/projects/<repository_name>/builds`


### PR DESCRIPTION
Added instructions for using ReadTheDocs to build and host Zensical sites, including an example configuration file.

Tested in:
- Repo: https://github.com/owid/owid-docs
- Live: https://docs.owid.io/