### PR TITLE
Fix syntax for `linenums_style` in TOML example

### DIFF
--- a/docs/setup/extensions/python-markdown-extensions.md
+++ b/docs/setup/extensions/python-markdown-extensions.md
@@ -419,7 +419,7 @@ line itself:
 
     ``` toml
     [project.markdown_extensions.pymdownx.highlight]
-    linenums_style: pymdownx-inline
+    linenums_style = "pymdownx-inline"
     ```
 
 === "`mkdocs.yml`"


### PR DESCRIPTION
`key: value` is yml syntax, not toml.