### PR TITLE
docs: fix attribute lists zensical.toml example to be ".attr_list"

### DIFF
--- a/docs/setup/extensions/python-markdown.md
+++ b/docs/setup/extensions/python-markdown.md
@@ -90,7 +90,7 @@ element with a special syntax. Enable it via:
 === "`zensical.toml`"
 
     ``` toml
-    [project.markdown_extensions.abbr]
+    [project.markdown_extensions.attr_list]
     ```
 
 === "`mkdocs.yml`"


### PR DESCRIPTION
Fix [attribute lists](https://zensical.org/docs/setup/extensions/python-markdown/#attribute-lists) zensical.toml example to be ".attr_list" instead of ".abbr"