### PR TITLE
add description of module, async, defer attributes

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -119,7 +119,7 @@ the `docs` directory:
   [instant navigation]: setup/navigation.md#instant-navigation
   [RxJS Observable]: https://rxjs.dev/api/index/class/Observable
 
-### Modules, `async`, `defer`
+#### Modules, `async`, `defer`
 
 Is you want to import code as a [JavaScript module], you can simply make sure
 that the file has the `.mjs` extension or you can explicitly specify that it is
@@ -128,7 +128,7 @@ to be loaded as a module:
 [JavaScript module]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
 
 === "`zensical.toml`"
-    ```toml
+    ``` toml
     [[project.extra_javascript]]
     path = "javascripts/extra.js"
     type = "module"
@@ -149,7 +149,7 @@ script tag to further influence how the JavaScript is loaded. For example, for
 the `async` case:
 
 === "`zensical.toml`"
-    ```toml
+    ``` toml
     [[project.extra_javascript]]
     path = "javascripts/extra.js"
     async = true


### PR DESCRIPTION
Looking at https://github.com/zensical/zensical/issues/183 it occurred to me that we do not have a description of the `type`, `async`, and `defer` attributes on `extra_javascript` in our documentation. Thought we should perhaps quickly add this instead of putting it on a todo list.