### PR TITLE
zensical:fix - Fix key name for configuring custom slugify function

### DIFF
--- a/docs/setup/extensions/python-markdown.md
+++ b/docs/setup/extensions/python-markdown.md
@@ -312,7 +312,7 @@ Python Markdown Extensions][Slugs]:
 
     ``` toml
     [project.markdown_extensions.toc.slugify]
-    function = "pymdownx.slugs.slugify"
+    object = "pymdownx.slugs.slugify"
     kwds = { case = "lower" }
     ```
 


### PR DESCRIPTION
Not sure about `zensical:fix` in the commit message summary, is that correct? Or should it be `docs:fix` maybe? 