### PR TITLE
Add missing  heading: `Repository URL`

### DIFF
--- a/docs/setup/repository.md
+++ b/docs/setup/repository.md
@@ -14,6 +14,8 @@ including stars and forks.
 
 ## Configuration
 
+### Repository URL
+
 In order to display a link to the repository of your project as part of your
 documentation, set `repo_url` in your configuration to the public URL of your
 repository, e.g.:


### PR DESCRIPTION
Add the missing `Repository URL` heading.