### PR TITLE
Fix typo in URL for MathJax JS in `python-markdown-extensions.md`

### DIFF
--- a/docs/setup/extensions/python-markdown-extensions.md
+++ b/docs/setup/extensions/python-markdown-extensions.md
@@ -78,7 +78,7 @@ of [additional JavaScript]:
     [project]
     extra_javascript = [
         "javascripts/mathjax.js",
-        "https://unpkg.com/mathjax@3/es5/tex-mml-chtml.j"
+        "https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"
     ]
     ```
 


### PR DESCRIPTION
This PR fixes a typo in the MathJax JS URL in the ` python-markdown-extensions.md` page.