### PR TITLE
fix: Gitlab CI configuration was updated for site publishing

### DIFF
--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -85,7 +85,7 @@ pages:
     - pip install zensical
     - zensical build --clean # (1)!
   pages:
-    publish: site
+    publish: public
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
 ```


### PR DESCRIPTION
Replacing artifacts with pages for site publishing. 

While migrating from Material to Zensical, I noticed the `--site-dir` flag was missing, which allows me to define which folder to use for saving rendered files.

By default, Zensical saves the rendered pages in the `site` folder; therefore, we need to explicitly define this folder as the target in the GitLab CI configuration.

About the configuration structure changes, you can check the discussion about it here: https://github.com/squidfunk/mkdocs-material/pull/8550