### PR TITLE
fix: extension defaults not additive (#59)

### DIFF
--- a/docs/setup/extensions/index.md
+++ b/docs/setup/extensions/index.md
@@ -83,6 +83,8 @@ most of the features listed in the [Authoring] part of this documentation.
 
 [Authoring]: ../../authoring/markdown.md
 
+If you define other extensions or need to change options on any of the default
+extensions, you will need to configure _all_ of the extensions you are using.
 The following is the full expansion of the default configuration that you
 can use as a starting point if you want to explicitly control what Markdown
 extensions are active in your project:
@@ -160,6 +162,13 @@ extensions are active in your project:
     MkDocs, which only activates `meta`, `toc`, `tables`, and `fenced_code`
     from Python Markdown itself. If you experience problems building your
     project, turn off the defaults, as shown below.
+
+!!! note "Presets are on the roadmap"
+    We are working on a [preset mechanism] that simplifies configuration and
+    will allow you to add extensions to a set of defaults, customize extensions
+    included in the defaults, as well as remove them.
+
+  [preset mechanism]: https://zensical.org/about/roadmap/#configuration
 
 ### Disable the defaults
 


### PR DESCRIPTION
I decided against using an admonition and made the explicit mention of the defaults being overridden part of the normal text. LMK if you think this needs to be highlighted more.

Also added a link to config/presets on our roadmap but put this at the end so it does not disrupt the flow in a critical section that we want people to remember.