### PR TITLE
Fix typo in `extra_css`

### DIFF
--- a/docs/setup/colors.md
+++ b/docs/setup/colors.md
@@ -388,7 +388,7 @@ custom colors, e.g., when you want to override the `primary` color:
 
 Let's say you're :fontawesome-brands-youtube:{ style="color: #EE0F0F" }
 __YouTube__, and want to set the primary color to your brand's palette. Just
-add this CSS and make sure that it is included in the `etxra_css` setting in
+add this CSS and make sure that it is included in the `extra_css` setting in
 your configuration:
 
 === "`docs/stylesheets/extra.css`"


### PR DESCRIPTION
This PR fixes a typo in the Colors page, which referred to `extra_css` as `etxra_css`.