### PR TITLE
Fix typo in docs/setup/analytics.md

### DIFF
--- a/docs/setup/analytics.md
+++ b/docs/setup/analytics.md
@@ -273,8 +273,8 @@ used to configure the custom integration:
 === "`zensical.toml`"
     ``` toml
     [project.extra.analytics]
-    provider: custom
-    property: foobar
+    provider = "custom"
+    property = "foobar"
     ```
 === "`mkdocs.yml`"
 


### PR DESCRIPTION
This PR fixes typos in docs/setup/analytics.md, correcting the TOML syntax.