### PR TITLE
fix(docs): remove extra colon

### DIFF
--- a/docs/setup/extensions/python-markdown.md
+++ b/docs/setup/extensions/python-markdown.md
@@ -239,7 +239,7 @@ The following configuration options are supported:
 
 This option sets the title of the table of contents in the right navigation
 sidebar, which is normally automatically sourced from the translations for
-the [site language]. Set the title explicitly via::
+the [site language]. Set the title explicitly via:
 
 === "`zensical.toml`"
 


### PR DESCRIPTION
Fixes doubled colon (`::`) to single colon (`:`) in [docs/setup/extensions/python-markdown.md](https://github.com/zensical/docs/blob/master/docs/setup/extensions/python-markdown.md).