### PR TITLE
chore: add note about external source files not being watched

### DIFF
--- a/docs/setup/extensions/mkdocstrings.md
+++ b/docs/setup/extensions/mkdocstrings.md
@@ -89,5 +89,5 @@ The complete list of options can be found here:
     follow progress on these backlog items:
 
     - [Proposal: Configuration](https://github.com/zensical/backlog/issues/47)
-        - [Allow use of `..` in `docs_dir` and `site_dir`](https://github.com/zensical/backlog/issues/56)
-        - [Symbolic links pointing outside of `docs_dir`](https://github.com/zensical/backlog/issues/55)
+    - [Allow use of `..` in `docs_dir` and `site_dir`](https://github.com/zensical/backlog/issues/56)
+    - [Symbolic links pointing outside of `docs_dir`](https://github.com/zensical/backlog/issues/55)


### PR DESCRIPTION
See https://github.com/zensical/zensical/issues/294#issuecomment-3794291705. Users can configure the Python handler to search for packages in paths that are external to the docs project (the directory containing the config file), but those paths will not be watched for changes (limitation).

<img width="783" height="345" alt="warning" src="https://github.com/user-attachments/assets/64b37e96-15a8-4f76-840d-4181bf366939" />
