### PR TITLE
Remove extra whitespace in table of contents config example

### DIFF
--- a/docs/setup/extensions/python-markdown.md
+++ b/docs/setup/extensions/python-markdown.md
@@ -222,7 +222,7 @@ page. Enable it via:
 
     ``` toml
     [project.markdown_extensions.toc]
-    permalink =  true
+    permalink = true
     ```
 
 === "`mkdocs.yml`"


### PR DESCRIPTION
Fix `permalink =  true` to `permalink = true` (remove extra space after equals sign)