### PR TITLE
add conda-forge install

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -155,7 +155,7 @@ be installed using [Anaconda] or [Mamba].
 
 === ":material-apple: macOS"
     ```sh
-    conda create -n zensical python=3.14.*
+    conda create -n zensical python=3.14
     conda activate zensical
     conda install -c conda-forge zensical
     ```
@@ -168,14 +168,14 @@ be installed using [Anaconda] or [Mamba].
     equivalent Miniforge Prompt.
 
     ```ps1
-    conda create -n zensical python=3.14.*
+    conda create -n zensical python=3.14
     conda activate zensical
     conda install -c conda-forge zensical
     ```
 
 === ":material-linux: Linux"
     ```sh
-    conda create -n zensical python=3.14.*
+    conda create -n zensical python=3.14
     conda activate zensical
     conda install -c conda-forge zensical
     ```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -125,3 +125,60 @@ use `uv run` or activate the project's virtual environment manually.
   [uvtool]: https://docs.astral.sh/uv/concepts/tools/#tool-environments
 
 
+!!! tip "Other tools using PyPI"
+    There are, of course, other dependency managers and build tools in the
+    Python ecosystem that use PyPI as the repository. Installing Zensical with
+    them should be similar to the process of installing with `uv`. Refer to
+    their documentation for details.
+
+## Third-party distributions
+
+There are other distributions that make Zensical available but they may or may
+not use the official packages we distribute exclusively through PyPI. You can
+use these distributions if you have good reasons to do so but for normal use we
+recommend the installation methods above that we officially support.
+
+
+### Install with Anaconda/Mamba { data-toc-label="Anaconda/Mamba" }
+
+Zensical is available in the [conda-forge] community repository so that it can
+be installed using [Anaconda] or [Mamba].
+
+  [conda-forge]: https://conda-forge.org/
+  [Anaconda]: https://www.anaconda.com
+  [Mamba]: https://mamba.readthedocs.io
+
+!!! warning
+    We cannot provide support for distributions we do not control. If you
+    experience any issues please contact the maintainers of the packages within
+    these distributions.
+
+=== ":material-apple: macOS"
+    ```sh
+    conda create -n zensical python=3.14.*
+    conda activate zensical
+    conda install -c conda-forge zensical
+    ```
+
+=== ":fontawesome-brands-windows: Windows"
+
+    If you are using Anaconda or Mamaba, make sure that the base environment is
+    activated. If you are using Anaconda, you can just open an [Anaconda
+    Prompt]. If you installed Mamba as part of [Miniforge], there will be an
+    equivalent Miniforge Prompt.
+
+    ```ps1
+    conda create -n zensical python=3.14.*
+    conda activate zensical
+    conda install -c conda-forge zensical
+    ```
+
+=== ":material-linux: Linux"
+    ```sh
+    conda create -n zensical python=3.14.*
+    conda activate zensical
+    conda install -c conda-forge zensical
+    ```
+
+[Anaconda Prompt]: https://www.anaconda.com/docs/reference/glossary#anaconda-prompt
+[Miniforge]: https://conda-forge.org/download/

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -150,11 +150,13 @@ be installed using [Anaconda] or [Mamba].
 
 !!! warning
     We cannot provide support for distributions we do not control. If you
-    experience any issues please contact the maintainers of the packages within
-    these distributions.
+    experience any issues please contact the maintainers of
+    [conda-forge/zensical-feedstock].
+
+  [conda-forge/zensical-feedstock]: https://github.com/conda-forge/zensical-feedstock
 
 === ":material-apple: macOS"
-    ```sh
+    ```
     conda create -n zensical python=3.14
     conda activate zensical
     conda install -c conda-forge zensical
@@ -167,14 +169,14 @@ be installed using [Anaconda] or [Mamba].
     Prompt]. If you installed Mamba as part of [Miniforge], there will be an
     equivalent Miniforge Prompt.
 
-    ```ps1
+    ```
     conda create -n zensical python=3.14
     conda activate zensical
     conda install -c conda-forge zensical
     ```
 
 === ":material-linux: Linux"
-    ```sh
+    ```
     conda create -n zensical python=3.14
     conda activate zensical
     conda install -c conda-forge zensical


### PR DESCRIPTION
I added installation instructions for the Zensical package on `conda-forge`, with appropriate disclaimers.

I have added mention of Mamba to the text as this is the leaner, meaner, BSD-licensed alternative to Anaconda. As far as I can tell, the instructions for installing Zensical do not need to change if Mamba is installed through the recommended Miniforge distribution. Those who prefer a faster install can swap to installing with the `mamba` command but `conda` will also work. I stopped short of explaining the difference to keep things simple.

Tested with Miniforge on both Linux and Windows. Don't have a MacOS VM to test this at the moment.