### PR TITLE
fix: change Gitlab Pages default folder (#66)

### DIFF
--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -95,7 +95,7 @@ pages:
     Zensical.
 
 2.  The Gitlab documentation says that the SSG should adapt to Gitlab Pages,
-    which uses the folder `public` be default but it is possible to
+    which uses the folder `public` by default but it is possible to
     [configure the default folder] as shown here.
 
 [configure the default folder]: https://docs.gitlab.com/user/project/pages/introduction/#customize-the-default-folder
@@ -104,7 +104,13 @@ When a new commit is pushed to the [default branch] (e.g. `master` or `main`),
 the static site is automatically built and deployed. Push your changes to see
 the workflow in action.
 
-Your documentation is now published under `<username>.gitlab.io/<repository>`.
+!!! note "Gitlab Pages settings"
+    By default, Gitlab Pages publishes to a domain that includes a random
+    string. Untick the `Use unique domain` box in your Gitlab Pages settings for
+    your production deployment. Also make sure to set the visibility for Pages
+    under `Settings > General > Visibility` if you want a public site.
+
+Your documentation is will now be published under `<username>.gitlab.io/<repository>`.
 
   [GitLab Pages]: https://gitlab.com/pages
   [GitLab CI]: https://docs.gitlab.com/ee/ci/

--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -85,7 +85,7 @@ pages:
     - pip install zensical
     - zensical build --clean # (1)!
   pages:
-    publish: public
+    publish: site # (2)!
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
 ```
@@ -94,9 +94,11 @@ pages:
     functionality will undergo revisions as we optimize the performance of
     Zensical.
 
-!!! warning "Prerequisites"
-    Make sure to change [`site_dir`][site_dir] to `public` in your
-    configuration as GitLab requires this.
+2.  The Gitlab documentation says that the SSG should adapt to Gitlab Pages,
+    which uses the folder `public` be default but it is possible to
+    [configure the default folder] as shown here.
+
+[configure the default folder]: https://docs.gitlab.com/user/project/pages/introduction/#customize-the-default-folder
 
 When a new commit is pushed to the [default branch] (e.g. `master` or `main`),
 the static site is automatically built and deployed. Push your changes to see
@@ -112,7 +114,7 @@ Your documentation is now published under `<username>.gitlab.io/<repository>`.
 ## Other
 
 We cannot document every hosting provider here. The following community guides
-describe how to deploy a Zensical site elsewhere. If you find an issue with one of these 
+describe how to deploy a Zensical site elsewhere. If you find an issue with one of these
 guides, please contact the author.
 
 * [Azure Static Web Apps with GitHub Actions](https://zensical-guides.hypercat.net/azure-static-web-app-github/)


### PR DESCRIPTION
Changed the Gitlab Pages default folder to match our default `site_dir`. Added a code admonition to explain what we are doing and that the Gitlab documentation still describes the old ways.

Also, default Gitlab Pages settings seem to be for a site that is private and that is published under an obfuscated domain name. I added an admonition to change settings in order to get a public deployment.