### PR TITLE
Add community themes showcase

### DIFF
--- a/docs/community/themes.md
+++ b/docs/community/themes.md
@@ -1,0 +1,37 @@
+---
+icon: lucide/palette
+---
+
+# Themes
+
+Theme extensions built and shared by the Zensical community using the
+[packaging mechanism][packaging] documented in the customization guide. Have
+you packaged your own? [Open a pull request][edit] to add it here.
+
+!!! note "Community-maintained"
+
+    Themes listed here are maintained by the community and are not officially
+    supported by Zensical.
+
+  [packaging]: ../customization.md#packaging-themes
+  [edit]: https://github.com/zensical/docs/edit/master/docs/community/themes.md
+
+<div class="grid cards" markdown>
+
+-   :material-coffee:{ .lg .middle } __Catppuccin for Zensical__
+
+    ---
+
+    A soothing pastel theme bringing the [Catppuccin] palette to Zensical, with
+    all four flavors: Latte, Frappé, Macchiato, and Mocha.
+
+    ---
+
+    [:octicons-arrow-right-24: View on GitHub][catppuccin-source]
+    [:octicons-arrow-right-24: Preview][catppuccin-preview]
+
+</div>
+
+  [Catppuccin]: https://catppuccin.com
+  [catppuccin-source]: https://github.com/jonathan343/catppuccin-zensical
+  [catppuccin-preview]: https://jonathan343.github.io/catppuccin-zensical/

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -537,3 +537,7 @@ configuration:
     theme:
       name: my_theme
     ```
+
+For examples of packaged themes built by the community, see [Themes].
+
+  [Themes]: community/themes.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -225,6 +225,7 @@ nav:
     - Tooltips: authoring/tooltips.md
   - Community:
     - Get involved: community/get-involved.md
+    - Themes: community/themes.md
     - How we work: community/how-we-work.md
     - FAQs: community/faqs.md
     - Contribute:


### PR DESCRIPTION
## Overview

After hearing about support for installable themes in [v0.0.37](https://github.com/zensical/zensical/releases/tag/v0.0.37), I decided to create one for adding [Catppuccin to Zensical](https://jonathan343.github.io/catppuccin-zensical/). This PR adds a new community themes page so installable themes can be more easily discovered by users.

This is intended as a quick, lightweight solution for surfacing community themes in the docs.

## Summary

- Adds a new `Community > Themes` page
- Adds the Catppuccin Zensical theme as the first listed community theme
- Links to both the GitHub repository and live preview
- Adds a note that listed themes are community-maintained and not officially supported by Zensical
- Links to the themes page from the customization guide

## Additional Notes

This manual showcase is a starting point. A more robust approach could automatically collect and list community themes in the future, similar to zizmor’s trophy case:

https://docs.zizmor.sh/trophy-case/

## Testing

Built the docs locally and validated that the served content rendered correctly.

```sh
zensical build
zensical serve
```
