### PR TITLE
update copyright year

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ repo_url: https://github.com/zensical/zensical
 edit_uri: https://github.com/zensical/docs/edit/master/docs/
 
 # Copyright
-copyright: "&copy; 2025 Zensical LLC"
+copyright: "&copy; 2025 - 2026 Zensical LLC"
 
 # Configuration
 theme:


### PR DESCRIPTION
Time does, in fact, flow :hourglass_flowing_sand: 

I'm assuming the correct format is `2025 - xxxx`, to keep it similar to the [Material for MkDocs copyright format](https://github.com/squidfunk/mkdocs-material/blob/280423fd757dce67abd626bb9f8bc6bd4a92063e/mkdocs.yml#L33-L34).