### PR TITLE
Update installation references from Anaconda to conda

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -132,13 +132,13 @@ use these distributions if you have good reasons to do so but for normal use we
 recommend the installation methods above that we officially support.
 
 
-### Install with Anaconda/Mamba { data-toc-label="Anaconda/Mamba" }
+### Install with conda/Mamba { data-toc-label="conda/Mamba" }
 
 Zensical is available in the [conda-forge] community repository so that it can
-be installed using [Anaconda] or [Mamba].
+be installed using [conda] or [Mamba].
 
   [conda-forge]: https://conda-forge.org/
-  [Anaconda]: https://www.anaconda.com
+  [conda]: https://docs.conda.io/en/latest/
   [Mamba]: https://mamba.readthedocs.io
 
 !!! warning
@@ -157,8 +157,8 @@ be installed using [Anaconda] or [Mamba].
 
 === ":fontawesome-brands-windows: Windows"
 
-    If you are using Anaconda or Mamaba, make sure that the base environment is
-    activated. If you are using Anaconda, you can just open an [Anaconda
+    If you are using conda or Mamba, make sure that the base environment is
+    activated. If you are using conda, you can just open an [Anaconda
     Prompt]. If you installed Mamba as part of [Miniforge], there will be an
     equivalent Miniforge Prompt.
 


### PR DESCRIPTION
Hello 👋,

I'm one of the conda maintainers and wanted to make a few corrections.

Anaconda is a company and packaging distribution, but "conda" is the tool. I decided to correct the references you made to "Anaconda" and replace it with "conda" where necessary. I know it's bit confusing, so I don't blame you for making the mistake.

I hope this suggested change makes sense. Happy to answer any questions you may have to hopefully make things as clear as possible for your users.