### PR TITLE
Don't suggest macro code should be in docs/ (fixes zensical/docs#114)

### DIFF
--- a/docs/setup/extensions/macros.md
+++ b/docs/setup/extensions/macros.md
@@ -41,7 +41,7 @@ Name of a Python module to load for defining variables, macros, and filters (def
 
     ``` toml
     [project.markdown_extensions.zensical.extensions.macros]
-    module_name = "docs/macros"
+    module_name = "macros"
     ```
 
 === "`mkdocs.yml`"
@@ -49,7 +49,7 @@ Name of a Python module to load for defining variables, macros, and filters (def
     ``` yaml
     markdown_extensions:
       - zensical.extensions.macros:
-          module_name: docs/macros
+          module_name: macros
     ```
 
 #### `modules`
@@ -116,7 +116,7 @@ Directory used as a Jinja2 template loader, enabling `{% include %}` tags in pag
 
     ``` toml
     [project.markdown_extensions.zensical.extensions.macros]
-    include_dir = "docs/includes"
+    include_dir = "includes"
     ```
 
 === "`mkdocs.yml`"
@@ -124,7 +124,7 @@ Directory used as a Jinja2 template loader, enabling `{% include %}` tags in pag
     ``` yaml
     markdown_extensions:
       - zensical.extensions.macros:
-          include_dir: docs/includes
+          include_dir: includes
     ```
 
 #### `render_by_default`


### PR DESCRIPTION
The documentation for macros includes examples suggesting that it is normal to put the `.py` files and Jinja2 templates associated with macros under `docs/`, but it is better to have them outside of that directory tree, so they don't get copied into the generated site.

This PR specifically addresses zensical/docs#114 by removing the `docs/` prefix from the example given of the `module_name` setting. It also removes `docs/` from the example given of the `include_dir` setting.