### PR TITLE
add note that docker image is not for hosting sites

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -38,9 +38,10 @@ necessary dependencies alongside Zensical.
   [Python website]: https://www.python.org/
 
 !!! tip "Use with Docker"
-    If you are familiar with Docker and wish to use Zensical in a container then
-    you can use our [official Docker image]. For installation and usage
-    instructions, see the documentation on Docker Hub.
+    If you want to  run Zensical in a container for previews and builds, you
+    can use our [official Docker image]. Note that it's not intended for
+    hosting the site. For installation and usage instructions, see the
+    documentation on Docker Hub.
 
 [official Docker image]: https://hub.docker.com/r/zensical/zensical
 


### PR DESCRIPTION
This was still open after recent changes to the docker image. Hope the wording fits the bill. I did take out "Docker" in the first sentence since you can also use this with Podman or MacOS containers. Essentially any OCI-compliant container?