### PR TITLE
clarify repo_name (#136)

### DIFF
--- a/docs/setup/repository.md
+++ b/docs/setup/repository.md
@@ -52,9 +52,10 @@ automatically requested and rendered.
 
 ### Repository name
 
-Zensical will infer the source provider by examining the URL and try to set the
-_repository name_ automatically. If you wish to customize the name, set
-`repo_name` in your configuration:
+Zensical will infer the repository provider by examining the URL and set
+the repository name to it. Inferring more than the provider is not possible
+in the general case. With `repo_name`, you can override this default
+to anything you like:
 
 === "`zensical.toml`"
 


### PR DESCRIPTION
A suggested wording change to make clearer how repo_url and repo_name do and do not relate to each other.