### PR TITLE
Update GitHub Actions info on publish page

### DIFF
--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -19,7 +19,7 @@ charge and pretty easy to set up.
 
   [GitHub Pages]: https://pages.github.com/
 
-### Publish with GitHub Actions
+### with GitHub Actions
 
 Using [GitHub Actions] you can automate the deployment of your project
 documentation on pushes to a specific branch in your repository.

--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -67,7 +67,7 @@ jobs:
     Zensical.
 
 When a new commit is pushed to the branch you are using for deployment
-(for example, `master` or `main` as shown in the earlier workflow), the static site is automatically built and
+(e.g. `master` or `main`), the static site is automatically built and
 deployed. Push your changes to see the workflow in action.
 
 Your documentation should shortly appear at `<username>.github.io/<repository>`.

--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -25,7 +25,7 @@ Using [GitHub Actions] you can automate the deployment of your project
 documentation on pushes to a specific branch in your repository.
 
 !!! note "Prerequisite"
-    GitHub Pages for your repo must be configured [to publish using GitHub Actions][configure publishing source].
+    GitHub Pages for your repository must be configured [to publish using GitHub Actions][configure publishing source].
 
 If you created your site with `zensical new`, a publishing workflow was already created for your project in `.github/workflows/docs.yml`. If you don't already have this workflow, create a new GitHub Actions workflow at the root of your
 repository (e.g. `.github/workflows/docs.yml`) with the following contents:

--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -19,12 +19,16 @@ charge and pretty easy to set up.
 
   [GitHub Pages]: https://pages.github.com/
 
-### with GitHub Actions
+### Publish with GitHub Actions
 
 Using [GitHub Actions] you can automate the deployment of your project
-documentation. At the root of your repository, create a new GitHub Actions
-workflow, e.g. `.github/workflows/docs.yml`, and copy and paste the following
-contents:
+documentation on pushes to a specific branch in your repository.
+
+!!! note "Prerequisite"
+    GitHub Pages for your repo must be configured [to publish using GitHub Actions][configure publishing source].
+
+If you created your site with `zensical new`, a publishing workflow was already created for your project in `.github/workflows/docs.yml`. If you don't already have this workflow, create a new GitHub Actions workflow at the root of your
+repository (e.g. `.github/workflows/docs.yml`) with the following contents:
 
 ``` yaml
 name: Documentation
@@ -63,12 +67,13 @@ jobs:
     Zensical.
 
 When a new commit is pushed to the branch you are using for deployment
-(e.g. `master` or `main`), the static site is automatically built and
+(for example, `master` or `main` as shown in the earlier workflow), the static site is automatically built and
 deployed. Push your changes to see the workflow in action.
 
 Your documentation should shortly appear at `<username>.github.io/<repository>`.
 
   [GitHub Actions]: https://github.com/features/actions
+  [configure publishing source]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow
 
 ## GitLab Pages
 


### PR DESCRIPTION
- Add link out to configuring GitHub Pages to use GitHub Actions
- Clarify workflow is the same as is added when you run `zensical new`