### PR TITLE
fix: link to UI repository on GitHub instead of hardcoding templates/partials listing

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -252,6 +252,9 @@ new templates or partials:
 └─ main.html                           # Default page
 ```
 
+The contents of these files can be found in the
+[Zensical UI repository on GitHub][theme templates].
+
 ### Custom templates
 
 Some of your pages may need a different structure. Say, you want to have a
@@ -525,4 +528,5 @@ configuration:
 [template]: authoring/frontmatter.md#page-template
 [template language provided by MiniJinja]: https://docs.rs/minijinja/latest/minijinja/syntax/index.html
 [template option]: authoring/frontmatter.md#page-template
+[theme templates]: https://github.com/zensical/ui/tree/master/dist
 [theme structure]: #theme-structure


### PR DESCRIPTION
Closes #155.

We could also consider dynamically listing the locally installed files with an executed code block (get local install path with importlib.metadata, walk templates and print, output as tree fence), which would play better with versioned docs (which we don't have), since the GitHub link always points to master.