### PR TITLE
Add RTD docs to deploying page

### DIFF
--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -120,8 +120,7 @@ guides, please contact the author.
 
 - [Azure Static Web Apps with GitHub Actions](https://zensical-guides.hypercat.net/azure-static-web-app-github/)
 - [Azure Static Web Apps with Azure DevOps](https://zensical-guides.hypercat.net/azure-static-web-app-devops/)
-- [Deploying Zensical on Read the Docs
-](https://docs.readthedocs.com/platform/stable/intro/zensical.html)
+- [Deploying Zensical on Read the Docs](https://docs.readthedocs.com/platform/stable/intro/zensical.html)
 
 [configure publishing source]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow
 [configure the default folder]: https://docs.gitlab.com/user/project/pages/introduction/#customize-the-default-folder

--- a/docs/publish-your-site.md
+++ b/docs/publish-your-site.md
@@ -120,6 +120,8 @@ guides, please contact the author.
 
 - [Azure Static Web Apps with GitHub Actions](https://zensical-guides.hypercat.net/azure-static-web-app-github/)
 - [Azure Static Web Apps with Azure DevOps](https://zensical-guides.hypercat.net/azure-static-web-app-devops/)
+- [Deploying Zensical on Read the Docs
+](https://docs.readthedocs.com/platform/stable/intro/zensical.html)
 
 [configure publishing source]: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow
 [configure the default folder]: https://docs.gitlab.com/user/project/pages/introduction/#customize-the-default-folder


### PR DESCRIPTION
I talked with a few folks who are excited about Zensical at Djangocon, and they didn't know we already supported it. 

This is an external guide, as noted in the heading. Let me know if there's anything else you'd like us to add/change in order for it to be made official, as we're excited about the progress here and want to help where we can. 

Looking at it, I found a couple small improvements to make already. I'll get those in on our side, and hopefully we can get this merged as well ✨ 