### PR TITLE
fix: remove markdown-exec dependency

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install dependencies
-        run: pip install zensical markdown-exec
+        run: pip install zensical
 
       - name: Build documentation
         run: zensical build --strict

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install dependencies
-        run: pip install zensical markdown-exec
+        run: pip install zensical
 
       - name: Build documentation
         run: zensical build --clean --strict

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,7 +86,6 @@ extra_css:
 plugins:
   - search
   - tags
-  - markdown-exec
   - redirects:
       redirect_maps:
         setup/extensions/about.md: compatibility/markdown/index.md


### PR DESCRIPTION
We don't document markdown-exec anymore, so no Pyodide code fence, so no need for the package to be installed.