### PR TITLE
fix(usage): Fix the `new` command syntax

### DIFF
--- a/docs/usage/new.md
+++ b/docs/usage/new.md
@@ -15,7 +15,7 @@ does not yet exist, it will be created for you.
 ## Usage
 
 ``` sh
-zensical new [OPTIONS] PROJECT_DIRECTORY
+zensical new [OPTIONS] [PROJECT_DIRECTORY]
 ```
 
 The directory structure created within the project directory consists of:


### PR DESCRIPTION
Correct the syntax of the 'new' command in the 'Usage' section.
Add the missing square brackets to indicate that `PROJECT_DIRECTORY` is optional.